### PR TITLE
Idempotent binding parser

### DIFF
--- a/lib/batman.js
+++ b/lib/batman.js
@@ -2684,10 +2684,11 @@
 
 (function() {
   Batman.DOM.ReaderBindingDefinition = (function() {
-    function ReaderBindingDefinition(node, keyPath, view) {
+    function ReaderBindingDefinition(node, keyPath, view, identifier) {
       this.node = node;
       this.keyPath = keyPath;
       this.view = view;
+      this.identifier = identifier;
     }
 
     return ReaderBindingDefinition;
@@ -2947,11 +2948,12 @@
 
 (function() {
   Batman.DOM.AttrReaderBindingDefinition = (function() {
-    function AttrReaderBindingDefinition(node, attr, keyPath, view) {
+    function AttrReaderBindingDefinition(node, attr, keyPath, view, identifier) {
       this.node = node;
       this.attr = attr;
       this.keyPath = keyPath;
       this.view = view;
+      this.identifier = identifier;
     }
 
     return AttrReaderBindingDefinition;
@@ -3336,7 +3338,7 @@
     };
 
     BindingParser.prototype.parseNode = function(node) {
-      var attr, attrIndex, attribute, backingView, binding, bindingDefinition, bindings, isViewBacked, reader, value, _j, _k, _len1, _len2, _ref, _ref1, _ref2, _ref3;
+      var attr, attrIndex, attribute, backingView, binding, bindingDefinition, bindingIdentifier, bindings, isViewBacked, parsedBindings, reader, value, _j, _k, _len1, _len2, _ref, _ref1, _ref2, _ref3;
       isViewBacked = false;
       if (node.getAttribute && node.attributes) {
         bindings = [];
@@ -3356,7 +3358,15 @@
           if (isViewBacked && viewBackedBindings.indexOf(name) === -1) {
             continue;
           }
-          binding = attr ? (reader = Batman.DOM.attrReaders[name]) ? (bindingDefinition = new Batman.DOM.AttrReaderBindingDefinition(node, attr, value, this.view), reader(bindingDefinition)) : void 0 : (reader = Batman.DOM.readers[name]) ? (bindingDefinition = new Batman.DOM.ReaderBindingDefinition(node, value, this.view), reader(bindingDefinition)) : void 0;
+          bindingIdentifier = attr ? "" + name + "-" + attr + "=" + value : "" + name + "=" + value;
+          if (parsedBindings = Batman._data(node, 'bindings')) {
+            if (parsedBindings[bindingIdentifier]) {
+              continue;
+            }
+          } else {
+            parsedBindings = Batman._data(node, 'bindings', {});
+          }
+          binding = attr ? (reader = Batman.DOM.attrReaders[name]) ? (bindingDefinition = new Batman.DOM.AttrReaderBindingDefinition(node, attr, value, this.view, bindingIdentifier), reader(bindingDefinition)) : void 0 : (reader = Batman.DOM.readers[name]) ? (bindingDefinition = new Batman.DOM.ReaderBindingDefinition(node, value, this.view, bindingIdentifier), reader(bindingDefinition)) : void 0;
           if (binding != null ? binding.initialized : void 0) {
             this.once('bindingsInitialized', (function(binding) {
               return function() {
@@ -11213,13 +11223,16 @@
 
     function AbstractBinding(definition) {
       this._fireDataChange = __bind(this._fireDataChange, this);
-      var viewClass;
-      this.node = definition.node, this.keyPath = definition.keyPath, this.view = definition.view;
+      var viewClass, _ref;
+      this.node = definition.node, this.keyPath = definition.keyPath, this.view = definition.view, this.identifier = definition.identifier;
       if (definition.onlyObserve) {
         this.onlyObserve = definition.onlyObserve;
       }
       if (definition.skipParseFilter != null) {
         this.skipParseFilter = definition.skipParseFilter;
+      }
+      if ((_ref = Batman._data(this.node, "bindings")) != null) {
+        _ref[this.identifier] = this;
       }
       if (!this.skipParseFilter) {
         this.parseFilter();
@@ -11274,12 +11287,15 @@
     };
 
     AbstractBinding.prototype.die = function() {
-      var _ref;
+      var _ref, _ref1;
       this.forget();
       if ((_ref = this._batman.properties) != null) {
         _ref.forEach(function(key, property) {
           return property.die();
         });
+      }
+      if ((_ref1 = Batman._data(this.node, "bindings")) != null) {
+        delete _ref1[this.identifier];
       }
       this.node = null;
       this.keyPath = null;
@@ -11428,13 +11444,11 @@
         this.fromViewClass = true;
         this.viewInstance = new viewClassOrInstance;
       }
-      this.node.removeAttribute('data-view');
       if (options = this.viewInstance.constructor._batman.get('options')) {
         for (_i = 0, _len = options.length; _i < _len; _i++) {
           option = options[_i];
           attributeName = "data-view-" + (option.toLowerCase());
           if (keyPath = this.node.getAttribute(attributeName)) {
-            this.node.removeAttribute(attributeName);
             definition = new Batman.DOM.ReaderBindingDefinition(this.node, keyPath, this.superview);
             new Batman.DOM.ViewArgumentBinding(definition, option, this.viewInstance);
           }
@@ -11610,9 +11624,6 @@
       this.dataChange = __bind(this.dataChange, this);
       this.childBindingAdded = __bind(this.childBindingAdded, this);
       SelectBinding.__super__.constructor.apply(this, arguments);
-      this.node.removeAttribute('data-bind');
-      this.node.removeAttribute('data-source');
-      this.node.removeAttribute('data-target');
       this.backingView.on('childBindingAdded', this.childBindingAdded);
       this.backingView.initializeBindings();
     }
@@ -11922,7 +11933,6 @@
 
     DeferredRenderBinding.prototype.dataChange = function(value) {
       if (value && !this.backingView.isBound) {
-        this.node.removeAttribute('data-renderif');
         return this.backingView.initializeBindings();
       }
     };
@@ -12045,7 +12055,6 @@
       var contextAttribute;
       ContextBinding.__super__.constructor.apply(this, arguments);
       contextAttribute = this.attributeName ? "data-" + this.bindingName + "-" + this.attributeName : "data-" + this.bindingName;
-      this.node.removeAttribute(contextAttribute);
       this.node.insertBefore(document.createComment("batman-" + contextAttribute + "=\"" + this.keyPath + "\""), this.node.firstChild);
     }
 

--- a/src/view/binding_parser.coffee
+++ b/src/view/binding_parser.coffee
@@ -59,10 +59,7 @@ class Batman.BindingParser extends Batman.Object
         else
           "#{name}=#{value}"
 
-        if parsedBindings = Batman._data(node, 'bindings')
-          continue if parsedBindings[bindingIdentifier]
-        else
-          parsedBindings = Batman._data(node, 'bindings', {})
+        continue if Batman._data(node, 'bindings')?[bindingIdentifier]
 
         binding = if attr
           if reader = Batman.DOM.attrReaders[name]

--- a/src/view/binding_parser.coffee
+++ b/src/view/binding_parser.coffee
@@ -54,13 +54,23 @@ class Batman.BindingParser extends Batman.Object
       for [name, attr, value] in bindings.sort(@_sortBindings)
         continue if isViewBacked and viewBackedBindings.indexOf(name) == -1
 
+        bindingIdentifier = if attr
+          "#{name}-#{attr}=#{value}"
+        else
+          "#{name}=#{value}"
+
+        if parsedBindings = Batman._data(node, 'bindings')
+          continue if parsedBindings[bindingIdentifier]
+        else
+          parsedBindings = Batman._data(node, 'bindings', {})
+
         binding = if attr
           if reader = Batman.DOM.attrReaders[name]
-            bindingDefinition = new Batman.DOM.AttrReaderBindingDefinition(node, attr, value, @view)
+            bindingDefinition = new Batman.DOM.AttrReaderBindingDefinition(node, attr, value, @view, bindingIdentifier)
             reader(bindingDefinition)
         else
           if reader = Batman.DOM.readers[name]
-            bindingDefinition = new Batman.DOM.ReaderBindingDefinition(node, value, @view)
+            bindingDefinition = new Batman.DOM.ReaderBindingDefinition(node, value, @view, bindingIdentifier)
             reader(bindingDefinition)
 
         if binding?.initialized # FIXME when nextNode gets less stupid this can be immediate

--- a/src/view/bindings/abstract_binding.coffee
+++ b/src/view/bindings/abstract_binding.coffee
@@ -91,10 +91,11 @@ class Batman.DOM.AbstractBinding extends Batman.Object
   skipParseFilter: false
 
   constructor: (definition) ->
-    {@node, @keyPath, @view} = definition
+    {@node, @keyPath, @view, @identifier} = definition
     @onlyObserve = definition.onlyObserve if definition.onlyObserve
     @skipParseFilter = definition.skipParseFilter if definition.skipParseFilter?
 
+    Batman._data(@node, "bindings")?[@identifier] = this
 
     # Pull out the `@key` and filter from the `@keyPath`.
     @parseFilter() if not @skipParseFilter
@@ -139,6 +140,7 @@ class Batman.DOM.AbstractBinding extends Batman.Object
   die: ->
     @forget()
     @_batman.properties?.forEach (key, property) -> property.die()
+    delete Batman._data(@node, "bindings")?[@identifier]
 
     @node = null
     @keyPath = null

--- a/src/view/bindings/abstract_binding.coffee
+++ b/src/view/bindings/abstract_binding.coffee
@@ -95,7 +95,8 @@ class Batman.DOM.AbstractBinding extends Batman.Object
     @onlyObserve = definition.onlyObserve if definition.onlyObserve
     @skipParseFilter = definition.skipParseFilter if definition.skipParseFilter?
 
-    Batman._data(@node, "bindings")?[@identifier] = this
+    if nodeBindings = Batman._data(@node, "bindings") || nodeBindings = Batman._data(@node, "bindings", {})
+      nodeBindings[@identifier] = this
 
     # Pull out the `@key` and filter from the `@keyPath`.
     @parseFilter() if not @skipParseFilter

--- a/src/view/bindings/context_binding.coffee
+++ b/src/view/bindings/context_binding.coffee
@@ -14,7 +14,6 @@ class Batman.DOM.ContextBinding extends Batman.DOM.AbstractAttributeBinding
     else
       "data-#{@bindingName}"
 
-    @node.removeAttribute(contextAttribute)
     @node.insertBefore(document.createComment("batman-#{contextAttribute}=\"#{@keyPath}\""), @node.firstChild)
 
   dataChange: (proxiedObject) ->

--- a/src/view/bindings/deferred_render_binding.coffee
+++ b/src/view/bindings/deferred_render_binding.coffee
@@ -11,6 +11,5 @@ class Batman.DOM.DeferredRenderBinding extends Batman.DOM.AbstractBinding
 
   dataChange: (value) ->
     if value and not @backingView.isBound
-      @node.removeAttribute('data-renderif')
       @backingView.initializeBindings()
 

--- a/src/view/bindings/select_binding.coffee
+++ b/src/view/bindings/select_binding.coffee
@@ -14,10 +14,6 @@ class Batman.DOM.SelectBinding extends Batman.DOM.AbstractBinding
   constructor: (definition) ->
     super
 
-    @node.removeAttribute('data-bind')
-    @node.removeAttribute('data-source')
-    @node.removeAttribute('data-target')
-
     @backingView.on 'childBindingAdded', @childBindingAdded
     @backingView.initializeBindings()
 

--- a/src/view/bindings/view_binding.coffee
+++ b/src/view/bindings/view_binding.coffee
@@ -24,13 +24,10 @@ class Batman.DOM.ViewBinding extends Batman.DOM.AbstractBinding
       @fromViewClass = true
       @viewInstance = new viewClassOrInstance
 
-    @node.removeAttribute('data-view')
-
     if options = @viewInstance.constructor._batman.get('options')
       for option in options
         attributeName = "data-view-#{option.toLowerCase()}"
         if keyPath = @node.getAttribute(attributeName)
-          @node.removeAttribute(attributeName)
           definition = new Batman.DOM.ReaderBindingDefinition(@node, keyPath, @superview)
           new Batman.DOM.ViewArgumentBinding(definition, option, @viewInstance)
 

--- a/src/view/dom/attribute_readers.coffee
+++ b/src/view/dom/attribute_readers.coffee
@@ -1,7 +1,7 @@
 #= require ./dom
 
 class Batman.DOM.AttrReaderBindingDefinition
-  constructor: (@node, @attr, @keyPath, @view) ->
+  constructor: (@node, @attr, @keyPath, @view, @identifier) ->
 
 # `Batman.DOM.attrReaders` contains all the DOM directives which take an argument in their name, in the
 # `data-dosomething-argument="keypath"` style. This means things like foreach, binding attributes like

--- a/src/view/dom/readers.coffee
+++ b/src/view/dom/readers.coffee
@@ -1,7 +1,7 @@
 #= require ./dom
 
 class Batman.DOM.ReaderBindingDefinition
-  constructor: (@node, @keyPath, @view) ->
+  constructor: (@node, @keyPath, @view, @identifier) ->
 
 Batman.BindingDefinitionOnlyObserve =
   Data: 'data'


### PR DESCRIPTION
Related to the discussion in #839 

This PR adds a `bindings` object for all nodes with bindings, which allows the parser to skip bindings that already exist. The downside, of course, is more memory usage (approximately 1-2% more for binding-heavy pages). It does provide a convenient way to get at the bindings of a particular node though, which is valuable for debugging.

The current implementation would require switching the few places where we manually create binding definitions outside of the binding parser, which I haven't done yet.

@nickjs @SoapyIllusions worth considering this approach at all?