### PR TITLE
View dying: isolate properties before destroying them

### DIFF
--- a/src/event_emitter/event_emitter.coffee
+++ b/src/event_emitter/event_emitter.coffee
@@ -66,3 +66,6 @@ Batman.EventEmitter =
 
   isPrevented: (key) ->
     @event(key, false)?.isPrevented()
+
+  removeEvents: ->
+    event.clearHandlers() for _, event of @_batman.events

--- a/src/observable/observable.coffee
+++ b/src/observable/observable.coffee
@@ -15,6 +15,13 @@ Batman.Observable =
       return properties.getObject(key) or properties.setObject( key, new propertyClass(this, key ) )
     else
       return properties.getString(key) or properties.setString(key, new propertyClass(this, key))
+
+  isolateProperties: ->
+    @_batman.properties?.forEach (key, property) -> property.isolate()
+
+  destroyProperties: ->
+    @_batman.properties?.forEach (key, property) -> property.die()
+
   get: (key) ->
     @property(key).getValue()
   set: (key, val) ->

--- a/src/view/bindings/abstract_binding.coffee
+++ b/src/view/bindings/abstract_binding.coffee
@@ -137,8 +137,9 @@ class Batman.DOM.AbstractBinding extends Batman.Object
       @fire 'dataChange', value, @node
 
   die: ->
+    @isolateProperties()
     @forget()
-    @_batman.properties?.forEach (key, property) -> property.die()
+    @destroyProperties()
 
     @node = null
     @keyPath = null

--- a/src/view/view.coffee
+++ b/src/view/view.coffee
@@ -238,6 +238,8 @@ class Batman.View extends Batman.Object
 
     @fireAndCall('destroy')
 
+    @isolateProperties()
+
     @destroyBindings()
     @destroySubviews()
 
@@ -247,11 +249,9 @@ class Batman.View extends Batman.Object
 
     @removeFromSuperview()
 
-    @forget()
-    @_batman.properties?.forEach (key, property) -> property.die()
+    @destroyProperties()
 
-    if @_batman.events
-      event.clearHandlers() for _, event of @_batman.events
+    @removeEvents()
 
     @node = null
     @parentNode = null

--- a/tests/batman/view/view_test.coffee
+++ b/tests/batman/view/view_test.coffee
@@ -117,10 +117,11 @@ asyncTest 'die should forget observers and fire destroy', 2, ->
   '''
   node = helpers.render source, {}, (node, view) ->
     view.fire = fireSpy = createSpy()
-    view.forget = forgetSpy = createSpy()
+
+    view.property('foo.bar').clearHandlers = forgetSpy = createSpy()
     view.die()
-    ok fireSpy.called
-    ok forgetSpy.called
+    ok fireSpy.called, 'it fires destroy'
+    ok forgetSpy.called, 'it forgets observers'
     QUnit.start()
 
 test "should copy parent view's filters", ->


### PR DESCRIPTION
I hope to test this properly after getting #1082  going. 

I've notice that view accessors can return undefined during view dying. I think this might be due to accessors getting updated by other ones `unset`ting. My thought is, what if you isolated everything _first_, then killed all the properties? Then you can be sure you don't get random updates as properties die.

Hope to get perf tests to test this hunch.
